### PR TITLE
Update ansible support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-role-openldap
 =========
 
-Configure an openldap server
+Configure an openldap server.
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,15 +75,15 @@ openldap_default_user: ldap
 openldap_default_group: ldap
 openldap_default_sentinel_file: /etc/ldap/noslapd
 
-openldap_server_pidfile: /var/run/slapd/slapd.pid
-openldap_server_argsfile: /var/run/slapd/slapd.args
-openldap_server_modulepath: /usr/lib/ldap
+openldap_server_pidfile: /var/run/openldap/slapd.pid
+openldap_server_argsfile: /var/run/openldap/slapd.args
+openldap_server_modulepath: /var/lib/ldap
 openldap_server_directory: /usr/share/openldap-servers
 openldap_server_configuration: /etc/openldap/slapd.conf
 openldap_server_app_path: /etc/openldap
 openldap_client_configuration: /etc/openldap/ldap.conf
 
-openldap_schema_directory: /etc/ldap/schema
+openldap_schema_directory: /etc/openldap/schema
 
 openldap_server_tls: True
 openldap_server_tls_crt: "/etc/pki/tls/certs/hostcert.crt"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,7 @@
   failed_when:
     - initial_ldapquery.rc != 0
     - initial_ldapquery.rc != 4
+    - initial_ldapquery.rc != 255
 
 # The initial_ldapquery.rc conditional could be set to != 0 in case we do not want to run anything if the query above works
 - include: redhat.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,24 @@
 # tasks file for ansible-role-openldap
 #
 
+#- name: Install OpenLDAP packages on RedHat
+#  yum: name={{ item }} state=present
+#  with_items: openldap_packages 
+#  when: ansible_os_family == "RedHat"
+
 - name: Install OpenLDAP packages on RedHat
-  yum: name={{ item }} state=present
-  with_items: openldap_packages 
+  yum:
+    name: "{{ openldap_packages }}"
+    state: present
   when: ansible_os_family == "RedHat"
 
 - name: if this ldap query has return code 0, skip some ldap tasks
   command: ldapsearch -x -H ldap://localhost -b {{ openldap_server_suffix }}
   register: initial_ldapquery
-  ignore_errors: True
+  # ignore_errors: True
+  failed_when:
+    - initial_ldapquery.rc != 0
+    - initial_ldapquery.rc != 4
 
 # The initial_ldapquery.rc conditional could be set to != 0 in case we do not want to run anything if the query above works
 - include: redhat.yml

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -65,7 +65,12 @@
 - name: Add admin user
   command: ldapadd -Y EXTERNAL -H ldapi:/// -f /tmp/chrootpw.ldif 
   register: addldapadmin
-  ignore_errors: True
+  # ignore_errors: True
+  failed_when:
+    - addldapadmin.rc != 68
+    - addldapadmin.rc != 0
+  changed_when:
+    - addldapadmin.rc == 0
 
 # 18: no equality matching rule
 - name: Assert addldapadmin status
@@ -80,12 +85,15 @@
 - name: Add basic schemas
   command:  ldapadd -Y EXTERNAL -H ldapi:/// -f {{ openldap_server_app_path }}/schema/{{ item }}.ldif 
   register: addldapschemas
-  with_items: openldap_server_schemas
-  ignore_errors: True
+  with_items: "{{ openldap_server_schemas }}"
+  # ignore_errors: True
+  failed_when:
+    - addldapschemas.rc != 80
+    - addldapschemas.rc != 0
 
 # 80: Duplicate attributeType:
 - name: Assert addldapschemas status
-  with_items: addldapschemas.results
+  with_items: "{{ addldapschemas.results }}"
   assert: 
     that:
       - item.rc == 80 or item.rc == 0
@@ -101,12 +109,18 @@
 - name: Change Domain
   command: ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/chdomain.ldif 
   register: ldapchangedomain
-  ignore_errors: True
+  # ignore_errors: True
+  failed_when:
+    - ldapchangedomain.rc != 0
+    - ldapchangedomain.rc != 18
+    - ldapchangedomain.rc != 20
+  changed_when:
+    - ldapchangedomain.rc == 0
 
 - name: Assert ldapchangedomain status
   assert: 
     that:
-      - ldapchangedomain.rc == 18 or ldapchangedomain.rc == 0
+      - ldapchangedomain.rc == 18 or ldapchangedomain.rc == 0 or ldapchangedomain.rc == 20
 
 # Remove chdomain?
 
@@ -119,10 +133,14 @@
     mode=0600
 
 - name: Setup Base Domain
-  command: ldapadd -x -D {{ openldap_server_rootdn }} -w "{{ openldap_admin_password }}" -f /tmp/basedomain.ldif 
+  command: ldapadd -x -D {{ openldap_server_rootdn }} -w {{ openldap_admin_password }} -f /tmp/basedomain.ldif 
   register: ldapbasedomain
-  ignore_errors: True
-
+  # ignore_errors: True
+  failed_when:
+  - ldapbasedomain.rc != 0
+  - ldapbasedomain.rc != 68
+  changed_when:
+  - ldapbasedomain.rc == 0
 
 # 68: Already exists (68)
 - name: Assert ldapchangedomain status
@@ -132,3 +150,7 @@
 
 - name: run an ldapquery at the end to make sure it responds
   command: ldapsearch -x -H ldap://localhost -b {{ openldap_server_suffix }}
+  register: ldaprespondtest
+  failed_when:
+    - ldaprespondtest.rc != 0
+    - ldaprespondtest.rc != 4

--- a/templates/chrootpw.ldif
+++ b/templates/chrootpw.ldif
@@ -1,5 +1,5 @@
 # specify the password generated above for "olcRootPW" section
 dn: olcDatabase={0}config,cn=config
 changetype: modify
-add: olcRootPW
+replace: olcRootPW
 olcRootPW: {{ ldapregrootpw.stdout }}


### PR DESCRIPTION
Updated ansible-role-openldap role, to work with Ansible 2.9, and current CentOS7 openldap packages, few default paths changed. Tested updated version with CentOS7. 